### PR TITLE
Add argument to constructor in examples

### DIFF
--- a/examples/deno.ts
+++ b/examples/deno.ts
@@ -11,7 +11,9 @@ async function bootstrap() {
   bot.use(
     session({
       initial: () => ({ counter: 0 }),
-      storage: new FileAdapter(),
+      storage: new FileAdapter({
+        dirName: "sessions",
+      }),
     })
   );
   

--- a/examples/node.ts
+++ b/examples/node.ts
@@ -11,7 +11,9 @@ async function bootstrap() {
   bot.use(
     session({
       initial: () => ({ counter: 0 }),
-      storage: new FileAdapter(),
+      storage: new FileAdapter({
+        dirName: "sessions",
+      }),
     })
   );
   


### PR DESCRIPTION
I have no clue if the formatting is as expected. Using `deno fmt` basically reformats everything and there is no other script defined in the `package.json` that seems to be for the formatting.

Also `deno lint` seems not to be used in the CI. I didn't create additional problems there I think.

Something unrelated I noticed in the `package.json`: The scripts don't need `npx` as they already search for packages installed. `npx` can simply be omitted there. (Also `npx` is a mostly unmaintained security hazard with way to much logic for its job.)